### PR TITLE
Update URLs

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -24,7 +24,7 @@ _Useful guides and resources to prepare you for the work ahead._
 * [Structure](https://www.newyorker.com/magazine/2013/01/14/structure), John McPhee
 
 ## Design ethics
-* [10 Timeframes](https://contentsmagazine.com/articles/10-timeframes//), Paul Ford
+* [10 Timeframes](https://contentsmagazine.com/articles/10-timeframes/), Paul Ford
 * [Slow Ideas](https://www.newyorker.com/magazine/2013/07/29/slow-ideas), Atul Gawande
 * [Investigating Normal: Technology and Ability](https://vimeo.com/134764010), Sara Hendren
 * [The Pitfalls of Trying to Read a Co-Worker’s Mind](https://www.nytimes.com/2016/12/29/business/the-pitfalls-of-trying-to-read-a-co-workers-mind.html), Isaac Lidsky

--- a/resources.md
+++ b/resources.md
@@ -6,69 +6,69 @@ title: Resources
 _Useful guides and resources to prepare you for the work ahead._
 
 ## Writing and content design
-* [Words as Material](http://nicolefenton.com/words-as-material/), Nicole Fenton
-* [Interface Writing: Code for Humans](http://nicolefenton.com/interface-writing/), Nicole Fenton
-* [Write an About Page That Gets You Hired](http://99u.com/articles/51669/how-to-write-about-me-section), Nicole Fenton
-* [If You Are Writing an Essay or a Thesis](https://medium.com/@chappelltracker/if-you-are-writing-an-essay-or-a-thesis-7e6e0eaeedef#.mo9vm7mka), Chappell Ellison
-* [Core Model: Designing from the Inside Out](http://alistapart.com/article/the-core-model-designing-inside-out-for-better-results), Ida Aalen
+* [Words as Material](https://www.nicolefenton.com/words-as-material/), Nicole Fenton
+* [Interface Writing: Code for Humans](https://www.nicolefenton.com/interface-writing/), Nicole Fenton
+* [Write an About Page That Gets You Hired](https://99u.adobe.com/articles/51669/how-to-write-about-me-section), Nicole Fenton
+* [If You Are Writing an Essay or a Thesis](https://medium.com/@chappelltracker/if-you-are-writing-an-essay-or-a-thesis-7e6e0eaeedef), Chappell Ellison
+* [Core Model: Designing from the Inside Out](https://alistapart.com/article/the-core-model-designing-inside-out-for-better-results/), Ida Aalen
 * [Designing Case Studies: Showcasing a Human Centered Design Process](https://www.smashingmagazine.com/2015/02/designing-case-studies-human-centered-design-process/), Senongo Akpem
-* [You Are What You Document](http://www.ybrikman.com/writing/2014/05/05/you-are-what-you-document/), Yevgeniy Brikman
+* [You Are What You Document](https://www.ybrikman.com/writing/2014/05/05/you-are-what-you-document/), Yevgeniy Brikman
 * [Collaborative Information Architecture](https://www.slideshare.net/AbbyCovert/collaborative-information-architecture-ias17), Abby Covert
 * [Questions I Ask When Reviewing Design](https://signalvnoise.com/posts/3024-questions-i-ask-when-reviewing-a-design), Jason Fried
-* [Writing Comments in the Margins](https://teachingcenter.wustl.edu/resources/writing-assignments-feedback/commenting-on-student-writing/#MarginComments), Washington University Teaching Center
+* [Writing Comments in the Margins](https://ctl.wustl.edu/resources/commenting-on-student-writing/#margins), Washington University Teaching Center
 * [On Writing Interfaces Well](https://signalvnoise.com/posts/3633-on-writing-interfaces-well), Jonas Downey
 * [A Shorthand for Designing UI Flows](https://signalvnoise.com/posts/1926-a-shorthand-for-designing-ui-flows), Ryan Singer
-* [Cardsorting for Brand Attributes](http://appropriateinc.com/downloads/ContentStrategyAtWork_Chapter2Sample.pdf), Margot Bloomstein
-* [The Language of Modular Design](http://alistapart.com/article/language-of-modular-design), Alla Kholmatova
-* [How to Write a Thank You Note](http://www.themorningnews.org/article/how-to-write-a-thank-you-note), Leslie Harpold
-* [Structure](http://www.newyorker.com/magazine/2013/01/14/structure), John McPhee
+* [Cardsorting for Brand Attributes](https://appropriateinc.com/downloads/ContentStrategyAtWork_Chapter2Sample.pdf), Margot Bloomstein
+* [The Language of Modular Design](https://alistapart.com/article/language-of-modular-design/), Alla Kholmatova
+* [How to Write a Thank You Note](https://themorningnews.org/article/how-to-write-a-thank-you-note), Leslie Harpold
+* [Structure](https://www.newyorker.com/magazine/2013/01/14/structure), John McPhee
 
 ## Design ethics
-* [10 Timeframes](http://contentsmagazine.com/articles/10-timeframes/), Paul Ford
-* [Slow Ideas](http://www.newyorker.com/magazine/2013/07/29/slow-ideas), Atul Gawande
+* [10 Timeframes](https://contentsmagazine.com/articles/10-timeframes//), Paul Ford
+* [Slow Ideas](https://www.newyorker.com/magazine/2013/07/29/slow-ideas), Atul Gawande
 * [Investigating Normal: Technology and Ability](https://vimeo.com/134764010), Sara Hendren
 * [The Pitfalls of Trying to Read a Co-Worker’s Mind](https://www.nytimes.com/2016/12/29/business/the-pitfalls-of-trying-to-read-a-co-workers-mind.html), Isaac Lidsky
-* [This is What I Have Learned](http://voiceconference.aiga.org/transcripts/presentations/milton_glaser.pdf), Milton Glaser
-* [Software is Politics](https://www.fastcodesign.com/3066631/software-is-politics), adapted from [this talk](http://blog.memespring.co.uk/2016/11/23/oscon-2016/), Richard Pope
+* [This is What I Have Learned](https://voiceconference.aiga.org/transcripts/presentations/milton_glaser.pdf), Milton Glaser
+* [Software is Politics](https://www.fastcompany.com/3066631/software-is-politics), adapted from [this talk](https://richardpope.org/blog/2016/11/23/oscon-2016/), Richard Pope
 
 ## Storytelling
 * [Ten Rules for Writing: Part 1](https://www.theguardian.com/books/2010/feb/20/ten-rules-for-writing-fiction-part-one) and [Part 2](https://www.theguardian.com/books/2010/feb/20/10-rules-for-writing-fiction-part-two), with Zadie Smith, Margaret Atwood, Neil Gaiman, and others
-* [The Danger of a Single Story](https://www.ted.com/talks/chimamanda_adichie_the_danger_of_a_single_story), Chimamanda Ngozi Adichie
+* [The Danger of a Single Story](https://www.ted.com/talks/chimamanda_ngozi_adichie_the_danger_of_a_single_story), Chimamanda Ngozi Adichie
 * [The Shape of Stories](https://vimeo.com/53286941), Kurt Vonnegut
 * [On Storytelling](https://www.youtube.com/watch?v=f6ezU57J8YI), Ira Glass
-* [On Story](https://vimeo.com/143732791), George Saunders
+* [On Story](https://www.youtube.com/watch?v=1-1xNNrABw8), George Saunders
 * [The Paris Review: Interviews](https://www.theparisreview.org/interviews)
 * [Great Questions](https://storycorps.org/participate/great-questions/), StoryCorps
-* [Storytelling Your Way to a Better Job or Stronger Startup](https://www.nytimes.com/2014/12/13/your-money/storytelling-to-find-a-job-or-build-a-business.html?_r=0), Alina Tugend
+* [Storytelling Your Way to a Better Job or Stronger Startup](https://www.nytimes.com/2014/12/13/your-money/storytelling-to-find-a-job-or-build-a-business.html), Alina Tugend
 * [You Are Not a Storyteller](https://vimeo.com/98368484), Stefan Sagmeister
 
 ## Books
 
-* [Nicely Said: Writing for the Web with Style and Purpose](http://www.nicelysaid.co), Nicole Fenton and Kate Kiefer Lee
-* [How to Make Sense of Any Mess](http://abbytheia.com/makesense/), Abby Covert
-* [Several Short Sentences About Writing](http://www.penguinrandomhouse.com/books/93789/several-short-sentences-about-writing-by-verlyn-klinkenborg/9780307279415/), Verlyn Klinkenborg
-* [Bird by Bird: Some Instructions on Writing and Life](http://www.worldcat.org/title/bird-by-bird-some-instructions-on-writing-and-life/oclc/32132867), Anne Lamott
-* [Writing to Change the World](http://www.penguinrandomhouse.com/books/295019/writing-to-change-the-world-by-mary-pipher/9781594482533/), Mary Pipher
+* [Nicely Said: Writing for the Web with Style and Purpose](https://www.nicelysaid.co), Nicole Fenton and Kate Kiefer Lee
+* [How to Make Sense of Any Mess](https://abbycovert.com/make-sense/), Abby Covert
+* [Several Short Sentences About Writing](https://www.penguinrandomhouse.com/books/93789/several-short-sentences-about-writing-by-verlyn-klinkenborg/9780307279415/), Verlyn Klinkenborg
+* [Bird by Bird: Some Instructions on Writing and Life](https://www.worldcat.org/title/bird-by-bird-some-instructions-on-writing-and-life/oclc/32132867), Anne Lamott
+* [Writing to Change the World](https://www.penguinrandomhouse.com/books/295019/writing-to-change-the-world-by-mary-pipher-phd/9781594482533/), Mary Pipher
 * [Writing Down the Bones](http://nataliegoldberg.com/books/writing-down-the-bones/), Natalie Goldberg
-* [The Art of Communicating](https://www.harpercollins.com/9780062224675/the-art-of-communicating), Thich Nhat Hanh
-* [This Won’t Take But a Minute, Honey](http://www.harvard.com/book/this_wont_take_but_a_minute_honey1), Steve Almond
-* [Show Your Work](http://austinkleon.com/show-your-work/), Austin Kleon
+* [The Art of Communicating](https://www.harpercollins.com/products/the-art-of-communicating-thich-nhat-hanh?variant=32205775634466), Thich Nhat Hanh
+* [This Won’t Take But a Minute, Honey](https://www.harvard.com/book/this_wont_take_but_a_minute_honey1), Steve Almond
+* [Show Your Work](https://austinkleon.com/show-your-work/), Austin Kleon
 
 ## Style guides
-* [18F Content Guide](https://pages.18f.gov/content-guide/)
-* [Conscious Style Guide](http://consciousstyleguide.com/)
-* [Disability Language Style Guide](http://ncdj.org/style-guide/)
-* [Diversity Style Guide](http://www.diversitystyleguide.com)
-* [GLAAD Media Reference Guide](http://www.glaad.org/reference)
+* [18F Content Guide](https://content-guide.18f.gov)
+* [Conscious Style Guide](https://consciousstyleguide.com)
+* [Disability Language Style Guide](https://ncdj.org/style-guide/)
+* [Diversity Style Guide](https://www.diversitystyleguide.com)
+* [GLAAD Media Reference Guide](https://www.glaad.org/reference)
 * [GOV.UK Content Design Guide](https://www.gov.uk/guidance/content-design)
-* [MailChimp Content Style Guide](http://styleguide.mailchimp.com)
-* [Guide to Understanding Non-binary People](http://www.transmediawatch.org/Documents/non_binary.pdf)
+* [MailChimp Content Style Guide](https://styleguide.mailchimp.com)
+* [Guide to Understanding Non-binary People](https://transmediawatch.org/wp-content/uploads/2020/09/non_binary.pdf)
 
 ## Tools
 * [Atom](https://atom.io/)
-* [Google Drive](https://www.google.com/drive/)
-* [iA Writer](https://ia.net/writer/)
-* [Scrivener](https://www.literatureandlatte.com/scrivener.php)
-* [Ulysses](http://www.ulyssesapp.com/)
+* [Google Drive](https://drive.google.com/)
+* [iA Writer](https://ia.net/writer)
+* [Scrivener](https://www.literatureandlatte.com/scrivener/overview)
+* [Ulysses](https://ulysses.app)
 * [Trix](https://trix-editor.org)
-* [Wordnik](http://www.transmediawatch.org/Documents/non_binary.pdf)
+* [Wordnik](https://www.wordnik.com)


### PR DESCRIPTION
Hi Nicole!

I really love this resource list, and still sometimes refer my own design students to it. I noticed recently that a couple of the links were 404ing, so I thought I'd go through and hunt down new URLs for those. While I was at it, I cleaned up a few others, mostly just to switch to `https`.

Cheers,
Nevan

----

### General change notes

- prefer `https` where available
- update links with redirects
- fix broken links

### Major changes in need of review

- The George Saunders talk seems to have been DMCAd off of Vimeo, but I found a video of a talk with the same title on YouTube. Not 100% sure it's the same one though.
- The Guide to Understanding Non-Binary People PDF 404d. I think I found the correct new URL, but the title of the PDF doesn't match so could be worth double-checking.